### PR TITLE
Added content class in the menu props, currently the prop contentCla…s does not add the custom class in the component

### DIFF
--- a/src/components/VDPicker/VDPicker.js
+++ b/src/components/VDPicker/VDPicker.js
@@ -336,6 +336,7 @@ export default baseMixins.extend({
 
       const menuProps = {
         ...defaultMenuProps,
+        contentClass: this.contentClass,
         value: this.isMenuActive,
         origin: this.origin,
         allowOverflow: this.allowOverflow,

--- a/src/components/VDPicker/VDPickerAgenda/VDPickerAgenda.js
+++ b/src/components/VDPicker/VDPickerAgenda/VDPickerAgenda.js
@@ -131,7 +131,7 @@ export default baseMixins.extend({
             disableBodyScroll(targetElement);
             this.genOverlay();
           } else {
-            this.removeOverlay(false);
+            this.removeOverlay(true);
             enableBodyScroll(targetElement);
           }
         });


### PR DESCRIPTION
Hello,
I noticed that in the newest version the prop `contentClass` is not setting the class in the component. Digging around, I thought maybe the current change is why it does not work. With this fix, it works on my end but I am not sure if there are other places that need to be modified. I would like to fix this so, please let me know and I can add those changes for this feature to be functional again.
