### PR TITLE
Fix for 'isAllowed' test in VDPickerYears.spec.js

### DIFF
--- a/src/components/VDPicker/utils/helpers.js
+++ b/src/components/VDPicker/utils/helpers.js
@@ -139,7 +139,7 @@ function areSameDates (date, dateSelected, type = 'date') {
 
 function isBeforeDate (date, beforeDate, type = 'day') {
   if (type === 'year') {
-    return Boolean(beforeDate) && date < dayjs(beforeDate, 'YYYY-MM-DD').get(type);
+    return Boolean(beforeDate) && date < dayjs(`${beforeDate}-01-01`, 'YYYY-MM-DD').get(type);
   }
 
   const selectedDate = dayjs.isDayjs(date) ? date : dayjs(date).startOf('day');


### PR DESCRIPTION
The isBeforeDate(date, beforeDate, type) was failing to convert a simple number into a year, causing 2019 to be an invalid year between 2018 and 2020.

https://github.com/mathieustan/vue-datepicker/blob/62211caacb13943b548dfc4649a42fa0005b8526/tests/unit/components/VDPicker/VDPickerYears.spec.js#L185

Fixes #85